### PR TITLE
change SqlLoader to SqlRenderer; support using various template engines

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -7,7 +7,7 @@ sqlt是一个模仿mybatis的go sqlmapping 实现，本质上，sqlt是数据库
 go代码  
 
 	db := sqlx.Open(...)
-	loader := sqlt.NewDefaultSqlLoader("path/*.tpl")
+	loader := sqlt.NewDefaultSqlRender("path/*.tpl")
 	dbop := sqlt.New(db, loader)
 
 	param := make(map[string]interface{})
@@ -15,10 +15,10 @@ go代码
 	param["s"] = ...
 	result, e := dbop.Select("defget", param)
 
-模板
+default模板
 
 		{{define "defget"}}
-			select * from {{.a}} where 
+			select * from {{.a}} where
 			{{if and .w .s}}
 				and {{.w}} like '%{{.s}}%'
 			{{end}}
@@ -26,16 +26,16 @@ go代码
 			{{if .id}}
 				and id = :id
 			{{end}}
-			
+
 			{{if .g}}
 				group by {{.g}}
 			{{end}}
-			
+
 			{{if .h}}
 				having by {{.h}}
 			{{end}}
-			
+
 			{{if .o}}
 				order by {{.o}}
-			{{end}} 
+			{{end}}
 		{{end}}

--- a/common.go
+++ b/common.go
@@ -6,8 +6,8 @@ var (
 	nilParam = make(map[string]interface{})
 )
 
-func insertDeleteUpdate(l SqlLoader, ext sqlx.Ext, id string, param interface{}) (int64, error) {
-	sql, _, e := l.LoadSql(id, param)
+func insertDeleteUpdate(l SqlRenderer, ext sqlx.Ext, id string, param interface{}) (int64, error) {
+	sql, _, e := l.RenderSql(id, param)
 	oops(e)
 
 	var p = param
@@ -21,8 +21,8 @@ func insertDeleteUpdate(l SqlLoader, ext sqlx.Ext, id string, param interface{})
 	return result.RowsAffected()
 }
 
-func selectWithRowHandler(l SqlLoader, ext sqlx.Ext, id string, param interface{}, rh RowHandler) error {
-	sql, _, e := l.LoadSql(id, param)
+func selectWithRowHandler(l SqlRenderer, ext sqlx.Ext, id string, param interface{}, rh RowHandler) error {
+	sql, _, e := l.RenderSql(id, param)
 	oops(e)
 
 	var p = param

--- a/create.go
+++ b/create.go
@@ -2,6 +2,6 @@ package sqlt
 
 import "github.com/jmoiron/sqlx"
 
-func New(db *sqlx.DB, loader SqlLoader) *DbOp {
+func New(db *sqlx.DB, loader SqlRenderer) *DbOp {
 	return &DbOp{db: db, l: loader}
 }

--- a/impl.go
+++ b/impl.go
@@ -5,12 +5,12 @@ import "github.com/jmoiron/sqlx"
 type (
 	DbOp struct {
 		db *sqlx.DB
-		l  SqlLoader
+		l  SqlRenderer
 	}
 
 	TxOp struct {
 		tx *sqlx.Tx
-		l  SqlLoader
+		l  SqlRenderer
 	}
 
 	defRowHandler struct {

--- a/sqlt.go
+++ b/sqlt.go
@@ -1,8 +1,8 @@
 package sqlt
 
 type (
-	SqlLoader interface {
-		LoadSql(id string, data interface{}) (string, int, error)
+	SqlRenderer interface {
+		RenderSql(id string, data interface{}) (string, int, error)
 	}
 
 	ColScanner interface {

--- a/tpl.go
+++ b/tpl.go
@@ -2,22 +2,39 @@ package sqlt
 
 import (
 	"bytes"
+	"io"
 	"text/template"
 )
 
 type (
-	DefaultSqlLoader struct {
-		t *template.Template
+	Renderer interface {
+		Render(w io.Writer, id string, param interface{}) error
 	}
+
+	SqlRender struct {
+		t Renderer
+	}
+
+	defualtRender *template.Template
 )
 
-func (l *DefaultSqlLoader) LoadSql(id string, param interface{}) (string, int, error) {
+//defualtRender
+func (r *defualtRender) Render(w io.Writer, id string, param interface{}) error {
+	tpl := r.(*template.Template)
+	return tpl.ExecuteTemplate(w, id, param)
+}
+
+func (l *SqlRender) RenderSql(id string, param interface{}) (string, int, error) {
 	buffer := new(bytes.Buffer)
-	e := l.t.ExecuteTemplate(buffer, id, param)
+	e := l.t.Render(buffer, id, param)
 	return buffer.String(), 0, e
 }
 
-func NewDefaultSqlLoader(pattern string) *DefaultSqlLoader {
+func NewDefaultSqlRender(pattern string) *SqlRender {
 	tpl := template.Must(template.ParseGlob(pattern))
-	return &DefaultSqlLoader{t: tpl}
+	return &SqlRender{t: defualtRender(tpl)}
+}
+
+func NewSqlRender(r Renderer) *SqlRender {
+	return &SqlRender{t: r}
 }


### PR DESCRIPTION
add a Render interface to generate SQL, it can support not only standard library's template but also other template engines.
I also changed SqlLoader to SqlRender, to allow better readability.